### PR TITLE
Added support for video snaps

### DIFF
--- a/3do/theme.xml
+++ b/3do/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/ags/theme.xml
+++ b/ags/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/amiga/theme.xml
+++ b/amiga/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/amigacd32/theme.xml
+++ b/amigacd32/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/amstradcpc/theme.xml
+++ b/amstradcpc/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/apple2/theme.xml
+++ b/apple2/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/arcade/theme.xml
+++ b/arcade/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/arcadia/theme.xml
+++ b/arcadia/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/atari2600/theme.xml
+++ b/atari2600/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/atari5200/theme.xml
+++ b/atari5200/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/atari7800/theme.xml
+++ b/atari7800/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/atari800/theme.xml
+++ b/atari800/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/atarijaguar/theme.xml
+++ b/atarijaguar/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/atarilynx/theme.xml
+++ b/atarilynx/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/atarist/theme.xml
+++ b/atarist/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/auto-allgames/theme.xml
+++ b/auto-allgames/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/auto-favorites/theme.xml
+++ b/auto-favorites/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/auto-lastplayed/theme.xml
+++ b/auto-lastplayed/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/bbcmicro/theme.xml
+++ b/bbcmicro/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/c128/theme.xml
+++ b/c128/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/c64/theme.xml
+++ b/c64/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/capcom/theme.xml
+++ b/capcom/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/channelf/theme.xml
+++ b/channelf/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/coco/theme.xml
+++ b/coco/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/colecovision/theme.xml
+++ b/colecovision/theme.xml
@@ -13,7 +13,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/common.xml
+++ b/common.xml
@@ -45,7 +45,7 @@ based on:		"carbon" by eric hettervik
 
 
 <!-- Game View - All -->
-    <view name="basic, detailed">
+    <view name="basic, detailed, video">
 	<!-- Page Layout -->
 		<image name="background" extra="true">		
 			<origin>0 0</origin>
@@ -139,8 +139,8 @@ based on:		"carbon" by eric hettervik
 	</view>
 
 
-<!-- Game View - Detailed -->
-	<view name="detailed">
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	<!-- Metadata -->
 		<text name="md_lbl_players, md_lbl_genre, md_lbl_developer, md_lbl_publisher, md_lbl_releasedate">
 			<fontPath>./common/fonts/Lato-Black.ttf</fontPath>

--- a/common/colorsets/alittleshort.xml
+++ b/common/colorsets/alittleshort.xml
@@ -29,7 +29,7 @@
 	
 	
 <!-- Game View - All -->
-    <view name="basic, detailed">
+    <view name="basic, detailed, video">
 	<!-- Page Layout -->
 		<image name="background" extra="true">
 			<path>./../images/stardust_light.png</path>
@@ -86,8 +86,8 @@
 	</view>
 
 
-<!-- Game View - Detailed -->
-	<view name="detailed">
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	<!-- Game Image -->
 		<image name="image-matte" extra="true">
 			<color>000000F6</color>

--- a/common/colorsets/bigguy.xml
+++ b/common/colorsets/bigguy.xml
@@ -29,7 +29,7 @@
 	
 	
 <!-- Game View - All -->
-    <view name="basic, detailed">
+    <view name="basic, detailed, video">
 	<!-- Page Layout -->
 		<image name="background" extra="true">
 			<path>./../images/binding_dark.png</path>
@@ -86,8 +86,8 @@
 	</view>
 
 
-<!-- Game View - Detailed -->
-	<view name="detailed">
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	<!-- Game Image -->
 		<image name="image-matte" extra="true">
 			<color>000000AA</color>

--- a/common/colorsets/copilot.xml
+++ b/common/colorsets/copilot.xml
@@ -29,7 +29,7 @@
 	
 	
 <!-- Game View - All -->
-    <view name="basic, detailed">
+    <view name="basic, detailed, video">
 	<!-- Page Layout -->
 		<image name="background" extra="true">
 			<path>./../images/stardust_dark.png</path>
@@ -86,8 +86,8 @@
 	</view>
 
 
-<!-- Game View - Detailed -->
-	<view name="detailed">
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	<!-- Game Image -->
 		<image name="image-matte" extra="true">
 			<color>25335499</color>

--- a/common/colorsets/hammertime.xml
+++ b/common/colorsets/hammertime.xml
@@ -37,7 +37,7 @@
 	
 	
 <!-- Game View - All -->
-    <view name="basic, detailed">
+    <view name="basic, detailed, video">
 	<!-- Page Layout -->
 		<image name="background" extra="true">
 			<path>./../images/binding_dark.png</path>
@@ -102,8 +102,8 @@
 	</view>
 
 
-<!-- Game View - Detailed -->
-	<view name="detailed">
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	<!-- Game Image -->
 		<image name="image-matte" extra="true">
 			<color>EDF7FFCC</color>

--- a/common/colorsets/huntergreen.xml
+++ b/common/colorsets/huntergreen.xml
@@ -29,7 +29,7 @@
 	
 	
 <!-- Game View - All -->
-    <view name="basic, detailed">
+    <view name="basic, detailed, video">
 	<!-- Page Layout -->
 		<image name="background" extra="true">
 			<path>./../images/stardust_dark.png</path>
@@ -86,8 +86,8 @@
 	</view>
 
 
-<!-- Game View - Detailed -->
-	<view name="detailed">
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	<!-- Game Image -->
 		<image name="image-matte" extra="true">
 			<color>A8A7A588</color>

--- a/common/colorsets/killercanadian.xml
+++ b/common/colorsets/killercanadian.xml
@@ -29,7 +29,7 @@
 	
 	
 <!-- Game View - All -->
-    <view name="basic, detailed">
+    <view name="basic, detailed, video">
 	<!-- Page Layout -->
 		<image name="background" extra="true">
 			<path>./../images/binding_dark.png</path>
@@ -86,8 +86,8 @@
 	</view>
 
 
-<!-- Game View - Detailed -->
-	<view name="detailed">
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	<!-- Game Image -->
 		<image name="image-matte" extra="true">
 			<color>0870E399</color>

--- a/common/colorsets/monodark.xml
+++ b/common/colorsets/monodark.xml
@@ -29,7 +29,7 @@
 	
 	
 <!-- Game View - All -->
-    <view name="basic, detailed">
+    <view name="basic, detailed, video">
 	<!-- Page Layout -->
 		<image name="background" extra="true">
 			<path>./../images/binding_dark.png</path>
@@ -86,8 +86,8 @@
 	</view>
 
 
-<!-- Game View - Detailed -->
-	<view name="detailed">
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	<!-- Game Image -->
 		<image name="image-matte" extra="true">
 			<color>000000AA</color>

--- a/common/colorsets/monolight.xml
+++ b/common/colorsets/monolight.xml
@@ -29,7 +29,7 @@
 	
 	
 <!-- Game View - All -->
-    <view name="basic, detailed">
+    <view name="basic, detailed, video">
 	<!-- Page Layout -->
 		<image name="background" extra="true">
 			<path>./../images/binding_light.png</path>
@@ -86,8 +86,8 @@
 	</view>
 
 
-<!-- Game View - Detailed -->
-	<view name="detailed">
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	<!-- Game Image -->
 		<image name="image-matte" extra="true">
 			<color>00000022</color>

--- a/common/colorsets/pops.xml
+++ b/common/colorsets/pops.xml
@@ -29,7 +29,7 @@
 	
 	
 <!-- Game View - All -->
-    <view name="basic, detailed">
+    <view name="basic, detailed, video">
 	<!-- Page Layout -->
 		<image name="background" extra="true">
 			<path>./../images/stardust_dark.png</path>
@@ -86,8 +86,8 @@
 	</view>
 
 
-<!-- Game View - Detailed -->
-	<view name="detailed">
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	<!-- Game Image -->
 		<image name="image-matte" extra="true">
 			<color>FFFFFF11</color>

--- a/common/colorsets/practicaleffects.xml
+++ b/common/colorsets/practicaleffects.xml
@@ -29,7 +29,7 @@
 	
 	
 <!-- Game View - All -->
-    <view name="basic, detailed">
+    <view name="basic, detailed, video">
 	<!-- Page Layout -->
 		<image name="background" extra="true">
 			<path>./../images/stardust_dark.png</path>
@@ -86,8 +86,8 @@
 	</view>
 
 
-<!-- Game View - Detailed -->
-	<view name="detailed">
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	<!-- Game Image -->
 		<image name="image-matte" extra="true">
 			<color>33302FDD</color>

--- a/common/colorsets/rcspaceman.xml
+++ b/common/colorsets/rcspaceman.xml
@@ -29,7 +29,7 @@
 	
 	
 <!-- Game View - All -->
-    <view name="basic, detailed">
+    <view name="basic, detailed, video">
 	<!-- Page Layout -->
 		<image name="background" extra="true">
 			<path>./../images/stardust_dark.png</path>
@@ -86,8 +86,8 @@
 	</view>
 
 
-<!-- Game View - Detailed -->
-	<view name="detailed">
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	<!-- Game Image -->
 		<image name="image-matte" extra="true">
 			<color>FFFFFF11</color>

--- a/common/colorsets/tinman.xml
+++ b/common/colorsets/tinman.xml
@@ -29,7 +29,7 @@
 	
 	
 <!-- Game View - All -->
-    <view name="basic, detailed">
+    <view name="basic, detailed, video">
 	<!-- Page Layout -->
 		<image name="background" extra="true">
 			<path>./../images/binding_dark.png</path>
@@ -86,8 +86,8 @@
 	</view>
 
 
-<!-- Game View - Detailed -->
-	<view name="detailed">
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	<!-- Game Image -->
 		<image name="image-matte" extra="true">
 			<color>00000099</color>

--- a/common/colorsets/worldwarrior.xml
+++ b/common/colorsets/worldwarrior.xml
@@ -29,7 +29,7 @@
 	
 	
 <!-- Game View - All -->
-    <view name="basic, detailed">
+    <view name="basic, detailed, video">
 	<!-- Page Layout -->
 		<image name="background" extra="true">
 			<path>./../images/binding_light.png</path>
@@ -86,8 +86,8 @@
 	</view>
 
 
-<!-- Game View - Detailed -->
-	<view name="detailed">
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	<!-- Game Image -->
 		<image name="image-matte" extra="true">
 			<color>000000EE</color>

--- a/common/templates/bigshot.xml
+++ b/common/templates/bigshot.xml
@@ -3,6 +3,30 @@
 	
 <!-- Game View - Detailed -->	
 	<view name="detailed">
+		<image name="md_image">
+			<origin>0.5 0.5</origin>
+			<pos>0.75215 0.55</pos>
+			<maxSize>0.388 0.6898</maxSize>
+		</image>
+	</view>
+
+<!-- Game View - Video -->
+	<feature supported="video">
+		<view name="video">
+			<video name="md_video">
+				<origin>0.5 0.5</origin>
+				<pos>0.75215 0.55</pos>
+				<maxSize>0.388 0.6898</maxSize>
+				<showSnapshotNoVideo>true</showSnapshotNoVideo>
+				<showSnapshotDelay>true</showSnapshotDelay>
+				<delay>2</delay>
+				<default></default>
+			</video>
+		</view>
+	</feature>
+
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	
 	<!-- Game Image 600x600 -->
 		<image name="image-matte" extra="true">
@@ -10,12 +34,6 @@
 			<origin>0.0 0.0</origin>
 			<pos>0.5343 0.16</pos>
 			<size>0.4357 0.7745</size>
-		</image>
-		
-		<image name="md_image">
-			<origin>0.5 0.5</origin>
-			<pos>0.75215 0.55</pos>
-			<maxSize>0.388 0.6898</maxSize>
 		</image>
 		
 	<!-- Metadata - Unused -->

--- a/common/templates/concise.xml
+++ b/common/templates/concise.xml
@@ -3,6 +3,30 @@
 	
 <!-- Game View - Detailed -->	
 	<view name="detailed">
+		<image name="md_image">
+			<origin>0.5 0.5</origin>
+			<pos>0.60205 0.55</pos>
+			<maxSize>0.3125 0.5555</maxSize>
+		</image>
+	</view>
+
+<!-- Game View - Video -->
+	<feature supported="video">
+		<view name="video">
+			<video name="md_video">
+				<origin>0.5 0.5</origin>
+				<pos>0.60205 0.55</pos>
+				<maxSize>0.3125 0.5555</maxSize>
+				<showSnapshotNoVideo>true</showSnapshotNoVideo>
+				<showSnapshotDelay>true</showSnapshotDelay>
+				<delay>2</delay>
+				<default></default>
+			</video>
+		</view>
+	</feature>
+
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	
 	<!-- Game Image 600x600 -->
 		<image name="image-matte" extra="true">
@@ -10,12 +34,6 @@
 			<origin>0.0 0.0</origin>
 			<pos>0.42 0.235</pos>						
 			<size>0.3641 0.63</size>
-		</image>
-		
-		<image name="md_image">
-			<origin>0.5 0.5</origin>
-			<pos>0.60205 0.55</pos>
-			<maxSize>0.3125 0.5555</maxSize>
 		</image>
 		
 	<!-- Metadata -->			

--- a/common/templates/landscape.xml
+++ b/common/templates/landscape.xml
@@ -3,6 +3,30 @@
 	
 <!-- Game View - Detailed -->	
 	<view name="detailed">
+		<image name="md_image">
+			<origin>0.5 0.5</origin>
+			<pos>0.60205 0.42495</pos>
+			<maxSize>0.3125 0.3704</maxSize>
+		</image>
+	</view>
+
+<!-- Game View - Video -->
+	<feature supported="video">
+		<view name="video">
+			<video name="md_video">
+				<origin>0.5 0.5</origin>
+				<pos>0.60205 0.42495</pos>
+				<maxSize>0.3125 0.3704</maxSize>
+				<showSnapshotNoVideo>true</showSnapshotNoVideo>
+				<showSnapshotDelay>true</showSnapshotDelay>
+				<delay>2</delay>
+				<default></default>
+			</video>
+		</view>
+	</feature>
+
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	
 	<!-- Game Image 600x400 -->
 		<image name="image-matte" extra="true">
@@ -11,12 +35,6 @@
 			<pos>0.42 0.2025</pos>						
 			<size>0.3641 0.4449</size>
 		</image>
-		
-		<image name="md_image">
-			<origin>0.5 0.5</origin>
-			<pos>0.60205 0.42495</pos>
-			<maxSize>0.3125 0.3704</maxSize>
-		</image>	
 		
 	<!-- Metadata -->			
 		<image name="meta-matte" extra="true">

--- a/common/templates/pic_and_desc.xml
+++ b/common/templates/pic_and_desc.xml
@@ -3,6 +3,30 @@
 	
 <!-- Game View - Detailed -->	
 	<view name="detailed">
+		<image name="md_image">
+			<origin>0.5 0.5</origin>
+			<pos>0.695 0.42495</pos>
+			<maxSize>0.47205 0.3704</maxSize>
+		</image>
+	</view>
+
+<!-- Game View - Video -->
+	<feature supported="video">
+		<view name="video">
+			<video name="md_video">
+				<origin>0.5 0.5</origin>
+				<pos>0.695 0.42495</pos>
+				<maxSize>0.47205 0.3704</maxSize>
+				<showSnapshotNoVideo>true</showSnapshotNoVideo>
+				<showSnapshotDelay>true</showSnapshotDelay>
+				<delay>2</delay>
+				<default></default>
+			</video>
+		</view>
+	</feature>
+
+<!-- Game View - Detailed, Video -->	
+	<view name="detailed, video">
 	
 	<!-- Game Image -->
 		<image name="image-matte" extra="true">
@@ -10,12 +34,6 @@
 			<origin>0.0 0.0</origin>
 			<pos>0.42 0.2025</pos>						
 			<size>0.55 0.4449</size>
-		</image>
-		
-		<image name="md_image">
-			<origin>0.5 0.5</origin>
-			<pos>0.695 0.42495</pos>
-			<maxSize>0.47205 0.3704</maxSize>
 		</image>
 		
 	<!-- Metadata - Unused -->

--- a/common/templates/portrait.xml
+++ b/common/templates/portrait.xml
@@ -3,6 +3,30 @@
 	
 <!-- Game View - Detailed -->	
 	<view name="detailed">
+		<image name="md_image">
+			<origin>0.5 0.5</origin>
+			<pos>0.5575 0.55</pos>
+			<maxSize>0.2084 0.5555</maxSize>
+		</image>
+	</view>
+
+<!-- Game View - Video -->
+	<feature supported="video">
+		<view name="video">
+			<video name="md_video">
+				<origin>0.5 0.5</origin>
+				<pos>0.5575 0.55</pos>
+				<maxSize>0.2084 0.5555</maxSize>
+				<showSnapshotNoVideo>true</showSnapshotNoVideo>
+				<showSnapshotDelay>true</showSnapshotDelay>
+				<delay>2</delay>
+				<default></default>
+			</video>
+		</view>
+	</feature>
+
+<!-- Game View - Detailed, Video -->
+	<view name="detailed, video">
 	
 	<!-- Game Image 400x600 -->
 		<image name="image-matte" extra="true">
@@ -10,12 +34,6 @@
 			<origin>0.0 0.0</origin>
 			<pos>0.42 0.235</pos>
 			<size>0.275 0.63</size>	
-		</image>
-		
-		<image name="md_image">
-			<origin>0.5 0.5</origin>
-			<pos>0.5575 0.55</pos>
-			<maxSize>0.2084 0.5555</maxSize>
 		</image>
 		
 	<!-- Metadata -->

--- a/crvision/theme.xml
+++ b/crvision/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/custom-collections/theme.xml
+++ b/custom-collections/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/daphne/theme.xml
+++ b/daphne/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/desktop/theme.xml
+++ b/desktop/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/dragon32/theme.xml
+++ b/dragon32/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/dreamcast/theme.xml
+++ b/dreamcast/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/famicom/theme.xml
+++ b/famicom/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/fba/theme.xml
+++ b/fba/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/fds/theme.xml
+++ b/fds/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/fm7/theme.xml
+++ b/fm7/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/gameandwatch/theme.xml
+++ b/gameandwatch/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/gamegear/theme.xml
+++ b/gamegear/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/gb/theme.xml
+++ b/gb/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/gba/theme.xml
+++ b/gba/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/gbc/theme.xml
+++ b/gbc/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/gc/theme.xml
+++ b/gc/theme.xml
@@ -13,7 +13,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/genesis/theme.xml
+++ b/genesis/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/intellivision/theme.xml
+++ b/intellivision/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/kodi/theme.xml
+++ b/kodi/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/limelight/theme.xml
+++ b/limelight/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/love/theme.xml
+++ b/love/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/macintosh/theme.xml
+++ b/macintosh/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/mame-advmame/theme.xml
+++ b/mame-advmame/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/mame-libretro/theme.xml
+++ b/mame-libretro/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/mame-mame4all/theme.xml
+++ b/mame-mame4all/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/mame/theme.xml
+++ b/mame/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/mastersystem/theme.xml
+++ b/mastersystem/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/megadrive/theme.xml
+++ b/megadrive/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/megadrivej/theme.xml
+++ b/megadrivej/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/mess/theme.xml
+++ b/mess/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/msx/theme.xml
+++ b/msx/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/n64/theme.xml
+++ b/n64/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/nds/theme.xml
+++ b/nds/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/neogeo/theme.xml
+++ b/neogeo/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/nes/theme.xml
+++ b/nes/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/ngp/theme.xml
+++ b/ngp/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/ngpc/theme.xml
+++ b/ngpc/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/odyssey2/theme.xml
+++ b/odyssey2/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/oric/theme.xml
+++ b/oric/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/pc/theme.xml
+++ b/pc/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/pc88/theme.xml
+++ b/pc88/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/pc98/theme.xml
+++ b/pc98/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/pce-cd/theme.xml
+++ b/pce-cd/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/pcengine/theme.xml
+++ b/pcengine/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/pcfx/theme.xml
+++ b/pcfx/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/ports/theme.xml
+++ b/ports/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/ps2/theme.xml
+++ b/ps2/theme.xml
@@ -13,7 +13,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/psp/theme.xml
+++ b/psp/theme.xml
@@ -13,7 +13,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/psx/theme.xml
+++ b/psx/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/residualvm/theme.xml
+++ b/residualvm/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/retropie/theme.xml
+++ b/retropie/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/samcoupe/theme.xml
+++ b/samcoupe/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/saturn/theme.xml
+++ b/saturn/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/scummvm/theme.xml
+++ b/scummvm/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/sega32x/theme.xml
+++ b/sega32x/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/segacd/theme.xml
+++ b/segacd/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/sfc/theme.xml
+++ b/sfc/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/sg-1000/theme.xml
+++ b/sg-1000/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/snes-pal/theme.xml
+++ b/snes-pal/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/snes/theme.xml
+++ b/snes/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/steam/theme.xml
+++ b/steam/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/stratagus/theme.xml
+++ b/stratagus/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/supergrafx/theme.xml
+++ b/supergrafx/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/tg-cd/theme.xml
+++ b/tg-cd/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/tg16/theme.xml
+++ b/tg16/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/ti99/theme.xml
+++ b/ti99/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/trs-80/theme.xml
+++ b/trs-80/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/vectrex/theme.xml
+++ b/vectrex/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/vic20/theme.xml
+++ b/vic20/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/videopac/theme.xml
+++ b/videopac/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/virtualboy/theme.xml
+++ b/virtualboy/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/wii/theme.xml
+++ b/wii/theme.xml
@@ -13,7 +13,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/wonderswan/theme.xml
+++ b/wonderswan/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/wonderswancolor/theme.xml
+++ b/wonderswancolor/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/x68000/theme.xml
+++ b/x68000/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/zmachine/theme.xml
+++ b/zmachine/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>

--- a/zxspectrum/theme.xml
+++ b/zxspectrum/theme.xml
@@ -14,7 +14,7 @@
 		</image>
 	</view>
 
-	<view name="basic, detailed">
+	<view name="basic, detailed, video">
 	<!-- System Specific Images -->
 		<image name="logo">
 			<path>./logo.svg</path>


### PR DESCRIPTION
Big fan if your work and this theme.  Been using it in all my local builds a while now. Hope you don't mind a quick pull request to add video snap support. 

Follows a similar style to the `es-the-nesmini` and a few others, where it displays the image for 2 seconds before displaying the video.  Very useful to smooth scrolling and provide a visual indicator of what the game is quickly without having to wait for the video to load.